### PR TITLE
API Helpers end-to-end example

### DIFF
--- a/examples/api_helpers_stream.py
+++ b/examples/api_helpers_stream.py
@@ -31,18 +31,17 @@ async def main():
         key=DEEPGRAM_API_KEY, audio_stream=mic_stream
     )
     async for user_message in deepgram_stream:
-        if user_message:
-            messages.append({"role": "user", "content": user_message})
-            llm_stream = await groq_client.chat.completions.create(
-                messages=messages, model=model_id, stream=True
-            )
-            groq_sentence_stream: AsyncIterator = groq.groq_sentence_stream(
-                llm_stream=llm_stream
-            )
-            async for sentence in elevenlabs.eleven_stream(
-                sentences=groq_sentence_stream, eleven_client=elevenlabs_client
-            ):
-                await asyncio.to_thread(stream, sentence)
+        messages.append({"role": "user", "content": user_message})
+        llm_stream = await groq_client.chat.completions.create(
+            messages=messages, model=model_id, stream=True
+        )
+        groq_sentence_stream: AsyncIterator = groq.groq_sentence_stream(
+            llm_stream=llm_stream
+        )
+        async for sentence in elevenlabs.eleven_stream(
+            sentences=groq_sentence_stream, eleven_client=elevenlabs_client
+        ):
+            await asyncio.to_thread(stream, sentence)
 
 
 if __name__ == "__main__":

--- a/examples/api_helpers_stream.py
+++ b/examples/api_helpers_stream.py
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import asyncio
+from typing import AsyncIterator
+
+from context import iftk
+from dotenv import dotenv_values
+from elevenlabs.client import ElevenLabs
+from elevenlabs.play import stream
+
+from iftk.helpers import deepgram, elevenlabs, groq, pyaudio
+
+DOTENV = dotenv_values(".env")
+GROQ_API_KEY = DOTENV["GROQ_API_KEY"]
+DEEPGRAM_API_KEY = DOTENV["DEEPGRAM_API_KEY"]
+ELEVENLABS_API_KEY = DOTENV["ELEVEN_API_KEY"]
+CHUNK = 512
+RATE = 16000
+model_id = "llama-3.1-8b-instant"
+messages = [{"role": "system", "content": "Answer to the user in a few sentences."}]
+
+
+async def main():
+    groq_client = groq.groq.AsyncClient(api_key=GROQ_API_KEY)
+    elevenlabs_client = ElevenLabs(api_key=ELEVENLABS_API_KEY)
+    mic_stream: AsyncIterator = pyaudio.microphone(rate=RATE, frames_per_buffer=CHUNK)
+    deepgram_stream: AsyncIterator = deepgram.deepgram_stream(
+        key=DEEPGRAM_API_KEY, audio_stream=mic_stream
+    )
+    async for user_message in deepgram_stream:
+        if user_message:
+            messages.append({"role": "user", "content": user_message})
+            llm_stream = await groq_client.chat.completions.create(
+                messages=messages, model=model_id, stream=True
+            )
+            groq_sentence_stream: AsyncIterator = groq.groq_sentence_stream(
+                llm_stream=llm_stream
+            )
+            async for sentence in elevenlabs.eleven_stream(
+                sentences=groq_sentence_stream, eleven_client=elevenlabs_client
+            ):
+                await asyncio.to_thread(stream, sentence)
+
+
+asyncio.run(main())

--- a/examples/api_helpers_stream.py
+++ b/examples/api_helpers_stream.py
@@ -45,4 +45,5 @@ async def main():
                 await asyncio.to_thread(stream, sentence)
 
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/context.py
+++ b/examples/context.py
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import iftk

--- a/iftk/helpers/deepgram.py
+++ b/iftk/helpers/deepgram.py
@@ -59,7 +59,8 @@ async def deepgram_stream(
         sender_task = asyncio.create_task(sender(ws))
 
         async for update in receiver(ws):
-            yield update
+            if update:
+                yield update
 
         tasks = [sender_task, keep_alive_task]
         for task in tasks:

--- a/tests/helpers/test_deepgram_stream.py
+++ b/tests/helpers/test_deepgram_stream.py
@@ -28,7 +28,6 @@ async def stream_file(filepath: str, chunk: int) -> AsyncIterator[bytes]:
     for _ in range(ceil(w.getnframes() / CHUNK)):
         data = w.readframes(chunk)
         yield data
-        await asyncio.sleep(0.0)
 
 
 class TestDeepgram(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
This PR adds an example of how to use the API helper functions in an async `Stream`-system friendly end-to-end example, from ASR (automatic speech recognition for user input) to TTS (text-to-speech responses based on LLM output).
## Rationale
The PR's main rationale is adding a friendly example to begin working with the `iftk` helper functions for streaming dialogue systems with unblocked tasks in an async fashion.
## Testing
This example has been tested locally, but tests for the helper functions can be found at `/tests/helpers`